### PR TITLE
連名の場合に twitter/github アカウントを複数書けるように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _site/
 .sass-cache/
+.jekyll-metadata
 
 /.bundle/
 /vendor/bundle

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ front matter (ファイル先頭の `---` と `---` で囲まれた部分) に�
 * length (必須): トークの長さ (`15` または `40`)
 * audience (必須): 聴衆の対象 (`Beginner`, `Intermediate` または `Advanced`)
 * language (必須): 発表言語 (`Japanese` または `English`)
-* twitter: Twitter アカウント
-* github: Github アカウント
+* twitter: Twitter アカウント (連名の場合はカンマ区切りで記載する。例: `taro,hanako`)
+* github: Github アカウント (連名の場合はカンマ区切りで記載する。例: `taro,hanako`)
 * icon: アイコンのURL
 * organization: 所属組織
 

--- a/_includes/github_icons.html
+++ b/_includes/github_icons.html
@@ -1,0 +1,9 @@
+{% if include.accounts %}
+{% assign accounts = include.accounts | split: "," %}
+{% for account in accounts %}
+<a class="btn btn-social-icon btn-github btn-xs"
+  href="https://github.com/{{ account | strip }}" target="_blank">
+  <i class="fa fa-github"></i>
+</a>
+{% endfor %}
+{% endif %}

--- a/_includes/twitter_icons.html
+++ b/_includes/twitter_icons.html
@@ -1,0 +1,9 @@
+{% if include.accounts %}
+{% assign accounts = include.accounts | split: "," %}
+{% for account in accounts %}
+<a class="btn btn-social-icon btn-twitter btn-xs"
+  href="https://twitter.com/{{ account | strip }}" target="_blank">
+  <i class="fa fa-twitter"></i>
+</a>
+{% endfor %}
+{% endif %}

--- a/_layouts/candidates_en.html
+++ b/_layouts/candidates_en.html
@@ -62,19 +62,9 @@ layout: default_en
     ({{ page.organization}})
     {% endif %}
 
-    {% if page.twitter %}
-    <a class="btn btn-social-icon btn-twitter btn-xs"
-     href="https://twitter.com/{{ page.twitter }}" target="_blank">
-      <i class="fa fa-twitter"></i>
-    </a>
-    {% endif %}
+    {% include twitter_icons.html accounts=page.twitter %}
+    {% include github_icons.html accounts=page.github %}
 
-    {% if page.github %}
-    <a class="btn btn-social-icon btn-github btn-xs"
-     href="https://github.com/{{ page.github }}" target="_blank">
-      <i class="fa fa-github"></i>
-    </a>
-    {% endif %}
   </dd>
 </dl>
 

--- a/_layouts/candidates_ja.html
+++ b/_layouts/candidates_ja.html
@@ -63,19 +63,8 @@ layout: default_ja
     ({{ page.organization}})
     {% endif %}
 
-    {% if page.twitter %}
-    <a class="btn btn-social-icon btn-twitter btn-xs"
-     href="https://twitter.com/{{ page.twitter }}" target="_blank">
-      <i class="fa fa-twitter"></i>
-    </a>
-    {% endif %}
-
-    {% if page.github %}
-    <a class="btn btn-social-icon btn-github btn-xs"
-     href="https://github.com/{{ page.github }}" target="_blank">
-      <i class="fa fa-github"></i>
-    </a>
-    {% endif %}
+    {% include twitter_icons.html accounts=page.twitter %}
+    {% include github_icons.html accounts=page.github %}
   </dd>
 </dl>
 


### PR DESCRIPTION
複数アイコン記載できるようにしました。

名前1、アイコン1、名前2、アイコン2というふうに並べられれば、より良さそうですが現状と構造が違うので手数が多くて辛そうです…

Fixes #170 