### PR TITLE
Add a dummy icon by default

### DIFF
--- a/_layouts/default_en.html
+++ b/_layouts/default_en.html
@@ -57,7 +57,7 @@
         </div>
         <ul class="nav navbar-nav navbar-right" id="cfp-voting-navi">
           <li class="dropdown" id="sign-out" style="display: none;">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"><img class="icon-mini img-responsive img-rounded" src="" id="user-pic"></a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"><img class="icon-mini img-responsive img-rounded" src="/img/common/no_img.png" id="user-pic"></a>
             <ul class="dropdown-menu">
               <li id="user-name"><span class="text"></span></li>
               <li id="ticket-code"><span class="text"></span></li>

--- a/_layouts/default_ja.html
+++ b/_layouts/default_ja.html
@@ -58,7 +58,7 @@
         </div>
         <ul class="nav navbar-nav navbar-right" id="cfp-voting-navi">
           <li class="dropdown" id="sign-out" style="display: none;">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"><img class="icon-mini img-responsive img-rounded" src="" id="user-pic"></a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"><img class="icon-mini img-responsive img-rounded" src="/img/common/no_img.png" id="user-pic"></a>
             <ul class="dropdown-menu">
               <li id="user-name"><span class="text"></span></li>
               <li id="ticket-code"><span class="text"></span></li>


### PR DESCRIPTION
Firefox 51 から src属性が空の img 要素が error イベントを発生させるように変更になる。

この関係で JavaScript エラーにならないよう、src にデフォルトではダミーアイコンを埋めておく。

参考)
https://www.fxsitecompat.com/ja/docs/2016/img-with-empty-src-will-fire-error-event/
https://bugzilla.mozilla.org/show_bug.cgi?id=599975