### PR TITLE
Topが変になっていたのを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,55 +197,19 @@ layout: null
     <section class="sectionStyle3" id="cfp">
       <header class="sectionHeadArea">
         <h2 class="clearfix">
-        	<span class="ttlSubLCenter">ボランティア募集</span>
+        	<span class="ttlSubLCenter">セッション募集</span>
         	<span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
         	<span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
         </h2>
-        <p class="subTtlSm">Volunteer</p>
+        <p class="subTtlSm"></p>
       </header>
       <div class="contArea cfp-link">
-      	ScalaMatsuri2017準備委員会では<a href="/volunteer/">当日運営ボランティア</a>を募集しています。
+      	セッション募集は終了しました。多数の応募ありがとうございました。
+      	<!-- Please refer to <a href="/en/cfp/">Scala Matsuri 2017 Call for Proposal</a>. -->
       </div>
     </section>
-
 		<section class="sectionStyle2" id="info">
 			<div class="sectionStyle2Inner">
-				<header class="sectionHeadArea w700">
-					<h2 class="clearfix">
-						<span class="ttlSubLCenter">セッション募集</span>
-						<span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
-						<span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
-					</h2>
-					<p class="subTtlSm">Call for proposal</p>
-				</header>
-				<div class="contArea">
-					<!--
-					<p>Scala に関する海外からのゲストスピーカーも招いた大規模な有料イベントです。 パラレルに 2 セッションで進行する予定です。一般募集のセッションや LT 大会も行う予定です。 懇親会についても行う予定ですが、現在調整中です。</p>
-					-->
-					<p>
-						また、<a href="https://twitter.com/scala_jp">twitter</a>や<a href="https://www.facebook.com/ScalaMatsuri">facebook</a>でも随時情報を発信していますので、是非フォロー/いいねをお願いします。
-					</p>
-					<table>
-						<tr>
-							<th>日程</th>
-							<td>2017年2月25日(土)、2017年2月26日(日)</td>
-						</tr>
-						<tr>
-							<th>会場</th>
-							<td>
-								<a href="http://www.jasso.go.jp/tiec/plazaheisei.html" target="_blank">
-									東京国際交流館
-								</a>
-							</td>
-						</tr>
-
-						<tr>
-							<th>チケット</th>
-							<td>参加にはチケットが必要です。<a href='https://scalaconfjp.doorkeeper.jp/events/53530'>こちら</a>からご購入下さい、。</td>
-						</tr>
-
-					</table>
-				</div>
 				<header class="sectionHeadArea">
 					<h2 class="clearfix">
 						<span class="ttlSubLCenter">開催概要</span>
@@ -528,6 +492,22 @@ layout: null
 			</div>
 		</section>
 
+
+	    <section class="sectionInquiry" id="volunteer">
+	      <header class="sectionHeadArea">
+	        <h2 class="clearfix">
+	        	<span class="ttlSubLCenter">ボランティア募集</span>
+	        	<span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
+	        	<span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
+	        </h2>
+	      </header>
+	      <div class="txtBlock">
+	      	<p>
+	      	ScalaMatsuri2017準備委員会では<a href="/volunteer/index.html"> 当日運営ボランティア</a>も募集しています。<br/>
+	      	運営にご興味のある方、一緒にScalaMatsuriを盛り上げていきたい方は是非ボランティアとしてのご参加も検討下さい。
+	        </p>
+	      </div>
+	    </section>
 		<section class="sectionStyle7" id="sp">
 			<header class="sectionHeadArea">
 				<h2 class="clearfix">


### PR DESCRIPTION
* セッション募集を終了文面に変更
* ボランティア募集の場所を下の方に移動

日本語できない人に来れれても持て余してしまうので、英語ページにはボランティア募集のページは作っていません。